### PR TITLE
Use WeakMap to cache EnumWrapper instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ wrappedRgb.forEach((value, key, wrappedEnum, index) => {
 
 ## Known Issues
 ### `WeakMap` Polyfill
-Some `WeakMap` polyfills store values directly on the "key" object (the run-time `enum` object, in this case) as a non-enumerable "secret" (randomly generated) property. This allows for quick O(1) constant time lookups and garbage collection of the value along with the key object, but does add a property to the object. The `WeakMap` secret property will NOT be iterated in `for ... in` loops, and will NOT be included in the results of `Object.keys()`, but it WILL be included in the result of `Object.getOwnPropertyNames()`. It's hard to imagine this actually causing any problems, so I have decided to go ahead with relying on `WeakMap`. If you run into a problem caused by this, please [report an issue on github](https://github.com/UselessPickles/ts-enum-util/issues).
+`WeakMap` polyfills typically store values directly on the "key" object (the run-time `enum` object, in this case) as a non-enumerable "secret" (randomly generated) property. This allows for quick O(1) constant time lookups and garbage collection of the value along with the key object, but does add a property to the object. The `WeakMap` secret property will NOT be iterated in `for ... in` loops, and will NOT be included in the results of `Object.keys()`, but it WILL be included in the result of `Object.getOwnPropertyNames()`.
+
+It's hard to imagine this actually causing any problems, and all mainstream browsers have natively supported `WeakMap` since about 2014-2015, so I have decided to go ahead with relying on `WeakMap`. If you run into a problem caused by this, please [report an issue on github](https://github.com/UselessPickles/ts-enum-util/issues).
 
 Read more about the use of `WeakMap` for caching `EnumWrapper` instances here: [Caching](#caching)
 
@@ -411,6 +413,8 @@ The use of the `WeakMap` means that even if you use `ts-enum-util` on temporary,
 Although `WeakMap` lookups can be extremely efficient (constant time lookups in typical implementations), beware that the ECMAScript specification only requires lookups to be "on average" less than O(n) linear time. As such, you should still excercise caution against needlessly obtaining cached references via `$enum` when making heavy use of `EnumWrapper` functionality. Consider storing the result of `$enum()` in a local variable before making multiple calls to its methods, especially if the `EnumWrapper`'s features are used within a loop.
 
 Despite the above warning, it is noteworthy that even the worst case implementation still produces extremely quick lookups for a relatively small number of items (like the number of enums that you are likely have in a project). For example, see [this performance test](https://www.measurethat.net/Benchmarks/Show/2513/5/map-keyed-by-object) of lookups into maps containing 500 entries, including a simple `Map` polyfill implementation.
+
+Read about a potential [`WeakMap` Polyfill issue](#weakmap-polyfill).
 
 Read more about `WeakMap` on the [MDN website](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,13 +29,12 @@ export class EnumWrapper<
     /**
      * Map of enum object -> EnumWrapper instance.
      * Used as a cache for {@link EnumWrapper.getCachedInstance} (and {@link $enum}).
-     * NOTE: Performance tests show that object key lookups into a Map (even if it's a slow polyfill) are plenty fast
-     *       for this use case of a relatively small number of items in the map, assuming you don't do something stupid
-     *       like lookup a cached instance within a tight loop. It's also an order of magnitude faster than building
-     *       a unique string key for each object and using a fast native Map with the generated string key:
-     *       {@link https://www.measurethat.net/Benchmarks/Show/2513/4/map-keyed-by-object}
+     * NOTE: WeakMap has very fast (constant time) lookups and avoids memory leaks if used on a temporary
+     *       enum-like object.
+     *       {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap}
+     *       {@link https://www.measurethat.net/Benchmarks/Show/2513/5/map-keyed-by-object}
      */
-    private static readonly instancesCache = new Map<object, EnumWrapper>();
+    private static readonly instancesCache = new WeakMap<object, EnumWrapper>();
 
     /**
      * List of all keys for this enum, in sorted order.

--- a/tests/$enum-both.test.ts
+++ b/tests/$enum-both.test.ts
@@ -7,25 +7,7 @@ enum TestEnum {
 }
 
 describe("$enum: number+string enum", () => {
-    test("useCache = true", () => {
-        const result1 = $enum(TestEnum, true);
-        const result2 = $enum(TestEnum, true);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns cached instance
-        expect(result1).toBe(result2);
-    });
-
-    test("useCache = false", () => {
-        const result1 = $enum(TestEnum, false);
-        const result2 = $enum(TestEnum, false);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns new instance
-        expect(result1).not.toBe(result2);
-    });
-
-    test("useCache = default (true)", () => {
+    test("returns cached instance", () => {
         const result1 = $enum(TestEnum);
         const result2 = $enum(TestEnum);
 

--- a/tests/$enum-number.test.ts
+++ b/tests/$enum-number.test.ts
@@ -7,25 +7,7 @@ enum TestEnum {
 }
 
 describe("$enum: number enum", () => {
-    test("useCache = true", () => {
-        const result1 = $enum(TestEnum, true);
-        const result2 = $enum(TestEnum, true);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns cached instance
-        expect(result1).toBe(result2);
-    });
-
-    test("useCache = false", () => {
-        const result1 = $enum(TestEnum, false);
-        const result2 = $enum(TestEnum, false);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns new instance
-        expect(result1).not.toBe(result2);
-    });
-
-    test("useCache = default (true)", () => {
+    test("returns cached instance", () => {
         const result1 = $enum(TestEnum);
         const result2 = $enum(TestEnum);
 

--- a/tests/$enum-string.test.ts
+++ b/tests/$enum-string.test.ts
@@ -7,25 +7,7 @@ enum TestEnum {
 }
 
 describe("$enum: string enum", () => {
-    test("useCache = true", () => {
-        const result1 = $enum(TestEnum, true);
-        const result2 = $enum(TestEnum, true);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns cached instance
-        expect(result1).toBe(result2);
-    });
-
-    test("useCache = false", () => {
-        const result1 = $enum(TestEnum, false);
-        const result2 = $enum(TestEnum, false);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns new instance
-        expect(result1).not.toBe(result2);
-    });
-
-    test("useCache = default (true)", () => {
+    test("returns cached instance", () => {
         const result1 = $enum(TestEnum);
         const result2 = $enum(TestEnum);
 

--- a/tests/EnumWrapper-both.test.ts
+++ b/tests/EnumWrapper-both.test.ts
@@ -34,6 +34,23 @@ describe("EnumWrapper: number+string enum", () => {
         expect(result1).toBe(result2);
     });
 
+    test("does not observably alter the enum", () => {
+        // Wrap the enum, then confirm that there are no extra properties/keys available
+        EnumWrapper.getCachedInstance(TestEnum);
+
+        expect(Object.keys(TestEnum)).toEqual(["0", "2", "D", "B", "A", "C"]);
+        expect(Object.getOwnPropertyNames(TestEnum)).toEqual(["0", "2", "D", "B", "A", "C"]);
+
+        const result = [];
+        for (const key in TestEnum) {
+            if (true) { // bypass tslint error
+                result.push(key);
+            }
+        }
+
+        expect(result).toEqual(["0", "2", "D", "B", "A", "C"]);
+    });
+
     describe("is Array-Like", () => {
         test("length", () => {
             expect(enumWrapper.length).toBe(4);

--- a/tests/EnumWrapper-both.test.ts
+++ b/tests/EnumWrapper-both.test.ts
@@ -10,19 +10,10 @@ enum TestEnum {
 }
 
 describe("EnumWrapper: number+string enum", () => {
-    const enumWrapper = EnumWrapper.createUncachedInstance(TestEnum);
+    const enumWrapper = EnumWrapper.getCachedInstance(TestEnum);
 
     test("toString()", () => {
         expect(String(enumWrapper)).toBe("[object EnumWrapper]");
-    });
-
-    test("createUncachedInstance()", () => {
-        const result1 = EnumWrapper.createUncachedInstance(TestEnum);
-        const result2 = EnumWrapper.createUncachedInstance(TestEnum);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns new instance
-        expect(result1).not.toBe(result2);
     });
 
     test("getCachedInstance()", () => {

--- a/tests/EnumWrapper-number.test.ts
+++ b/tests/EnumWrapper-number.test.ts
@@ -10,19 +10,10 @@ enum TestEnum {
 }
 
 describe("EnumWrapper: string enum", () => {
-    const enumWrapper = EnumWrapper.createUncachedInstance(TestEnum);
+    const enumWrapper = EnumWrapper.getCachedInstance(TestEnum);
 
     test("toString()", () => {
         expect(String(enumWrapper)).toBe("[object EnumWrapper]");
-    });
-
-    test("createUncachedInstance()", () => {
-        const result1 = EnumWrapper.createUncachedInstance(TestEnum);
-        const result2 = EnumWrapper.createUncachedInstance(TestEnum);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns new instance
-        expect(result1).not.toBe(result2);
     });
 
     test("getCachedInstance()", () => {

--- a/tests/EnumWrapper-number.test.ts
+++ b/tests/EnumWrapper-number.test.ts
@@ -34,6 +34,23 @@ describe("EnumWrapper: string enum", () => {
         expect(result1).toBe(result2);
     });
 
+    test("does not observably alter the enum", () => {
+        // Wrap the enum, then confirm that there are no extra properties/keys available
+        EnumWrapper.getCachedInstance(TestEnum);
+
+        expect(Object.keys(TestEnum)).toEqual(["0", "1", "2", "D", "B", "A", "C"]);
+        expect(Object.getOwnPropertyNames(TestEnum)).toEqual(["0", "1", "2", "D", "B", "A", "C"]);
+
+        const result = [];
+        for (const key in TestEnum) {
+            if (true) { // bypass tslint error
+                result.push(key);
+            }
+        }
+
+        expect(result).toEqual(["0", "1", "2", "D", "B", "A", "C"]);
+    });
+
     describe("is Array-Like", () => {
         test("length", () => {
             expect(enumWrapper.length).toBe(4);

--- a/tests/EnumWrapper-string.test.ts
+++ b/tests/EnumWrapper-string.test.ts
@@ -10,19 +10,10 @@ enum TestEnum {
 }
 
 describe("EnumWrapper: string enum", () => {
-    const enumWrapper = EnumWrapper.createUncachedInstance(TestEnum);
+    const enumWrapper = EnumWrapper.getCachedInstance(TestEnum);
 
     test("toString()", () => {
         expect(String(enumWrapper)).toBe("[object EnumWrapper]");
-    });
-
-    test("createUncachedInstance()", () => {
-        const result1 = EnumWrapper.createUncachedInstance(TestEnum);
-        const result2 = EnumWrapper.createUncachedInstance(TestEnum);
-
-        expect(result1 instanceof EnumWrapper).toBe(true);
-        // returns new instance
-        expect(result1).not.toBe(result2);
     });
 
     test("getCachedInstance()", () => {

--- a/tests/EnumWrapper-string.test.ts
+++ b/tests/EnumWrapper-string.test.ts
@@ -34,6 +34,23 @@ describe("EnumWrapper: string enum", () => {
         expect(result1).toBe(result2);
     });
 
+    test("does not observably alter the enum", () => {
+        // Wrap the enum, then confirm that there are no extra properties/keys available
+        EnumWrapper.getCachedInstance(TestEnum);
+
+        expect(Object.keys(TestEnum)).toEqual(["D", "B", "A", "C"]);
+        expect(Object.getOwnPropertyNames(TestEnum)).toEqual(["D", "B", "A", "C"]);
+
+        const result = [];
+        for (const key in TestEnum) {
+            if (true) { // bypass tslint error
+                result.push(key);
+            }
+        }
+
+        expect(result).toEqual(["D", "B", "A", "C"]);
+    });
+
     describe("is Array-Like", () => {
         test("length", () => {
             expect(enumWrapper.length).toBe(4);


### PR DESCRIPTION
Use a `WeakMap` instead of a `Map` to cache `EnumWrapper` instances. This ensures that `EnumWrapper` instances are garbage collected whenever their corresponding "enum-like" objects are garbage collected (no memory leaks), and should also improve  cache lookup performance.

Because `WeakMap` solves the concern about memory leaks when `ts-enum-util` is used on temporary enum-like objects, there's really no need to opt out of caching any more. So the following API changes were made:
* Removed `EnumWrapper.createUncachedInstance()`
* Removed optional `useCache` param to the `$enum()` function (it now always uses the cache).

The `$enum`  function was also slightly optimized by making it a direct reference to `EnumWrapper.getCachedInstance`.